### PR TITLE
修复clipboard名称为小写

### DIFF
--- a/src/views/font.vue
+++ b/src/views/font.vue
@@ -71,7 +71,7 @@
   import codeBox from '../components/codeBox'
   import apiTable from '../components/apiTable'
 
-  import Clipboard from 'Clipboard'
+  import Clipboard from 'clipboard'
 
   export default {
     data: function () {


### PR DESCRIPTION
在linux环境build报错：
ERROR in ./~/babel-loader?presets[]=es2015&plugins[]=transform-runtime&comments=false!./~/vue-loader/lib/selector.js?type=script&index=0!./src/views/font.vue
Module not found: Error: Cannot resolve module 'Clipboard' in /opt/myweb/vue-beauty/src/views
在node_module里"Clipboard"的名称为“clipboard”。

