### PR TITLE
穿梭组件添加上下排序按钮

### DIFF
--- a/src/docs/zh-cn/transfer.md
+++ b/src/docs/zh-cn/transfer.md
@@ -209,7 +209,7 @@ export default {
 
 ```html
 <template>
-  <v-transfer :data="dataSource3" :target-keys="targetKeys3" @change="handleChange3" :list-style="{width: '250px', height: '300px'}" show-search :operations="['向右', '向左']" :filter-option="filterOption" :label="render1">
+  <v-transfer :data="dataSource3" :target-keys="targetKeys3" @change="handleChange3" :list-style="{width: '250px', height: '300px'}" show-search :operations="['向左', '向右', '向上', '向下']" :filter-option="filterOption" :label="render1">
     <div :style="{float: 'right', margin: '5px'}" slot="leftFooter">
         <v-button type="ghost" size="small" @click="mockData2(3)">刷新</v-button>
     </div>

--- a/vb/components/transfer/operation.vue
+++ b/vb/components/transfer/operation.vue
@@ -7,6 +7,14 @@
 			{{operations[1]}}
 			<v-icon type="right"></v-icon>
 		</v-button>
+		<v-button type="primary" size="small" :disabled="!verticalActive" @click="moveUp">
+            {{operations[2]}}
+            <v-icon type="up"></v-icon>
+		</v-button>
+		<v-button type="primary" size="small" :disabled="!verticalActive" @click="moveDown">
+            {{operations[3]}}
+            <v-icon type="down"></v-icon>
+		</v-button>
 	</div>
 </template>
 <script>
@@ -33,11 +41,23 @@ export default {
             type: Boolean,
             default: false,
         },
+        verticalActive: {
+            type: Boolean,
+            default: false,
+        },
         moveToLeft: {
             type: Function,
             default: noop,
         },
         moveToRight: {
+            type: Function,
+            default: noop,
+        },
+        moveUp: {
+            type: Function,
+            default: noop,
+        },
+        moveDown: {
             type: Function,
             default: noop,
         },

--- a/vb/components/transfer/style/index.less
+++ b/vb/components/transfer/style/index.less
@@ -145,9 +145,9 @@
 
     .@{ant-prefix}-btn {
       display: block;
-
-      &:first-child {
-        margin-bottom: 4px;
+      margin-bottom: 4px;
+      &:last-child {
+        margin-bottom: 0;
       }
 
       .@{iconfont-css-prefix} {

--- a/vb/components/transfer/transfer.vue
+++ b/vb/components/transfer/transfer.vue
@@ -27,6 +27,9 @@
 		  :right-active="rightActive"
 		  :move-to-left = "moveToLeft"
 		  :move-to-right = "moveToRight"
+          :move-up = "moveUp"
+          :move-down = "moveDown"
+          :vertical-active="verticalActive"
 		 ></operation>
 		<list
 		  :filter="rightFilter"
@@ -108,6 +111,7 @@ export default {
             rightDataSource: [],
             leftActive: false,
             rightActive: false,
+            verticalActive: false,
             leftFilter: '',
             rightFilter: '',
         };
@@ -118,6 +122,7 @@ export default {
         },
         rightCheckedKeys() {
             this.rightActive = this.rightCheckedKeys.length > 0;
+            this.verticalActive = this.rightCheckedKeys.length === 1;
         },
         targetKeys() {
             this.splitDataSource();
@@ -206,6 +211,22 @@ export default {
         },
         moveToRight() {
             this.moveTo('right');
+        },
+        moveUp() {
+            this.moveVertical('up');
+        },
+        moveDown() {
+            this.moveVertical('down');
+        },
+        moveVertical(direction) {
+            const index = this.targetKeys.indexOf(this.rightCheckedKeys[0]);
+            if (index === 0 && direction === 'up') {
+                return;
+            }
+            const directFlag = direction === 'up' ? -1 : 1;
+            this.targetKeys.splice(index, 1);
+            this.targetKeys.splice(index + directFlag, 0, this.rightCheckedKeys[0]);
+            this.$emit('change', this.targetKeys, direction, this.rightCheckedKeys);
         },
         handleLeftClear() {
             this.leftFilter = '';


### PR DESCRIPTION
穿梭组件添加上下排序按钮，选择目标列表其中一项，点击上下按钮可对目标列表进行上下依次排序，并在change事件中获取排序列表、方向、目标元素。