### PR TITLE
return the case--this.$refs.inputArea is undefined

### DIFF
--- a/package/vue-beauty.js
+++ b/package/vue-beauty.js
@@ -29558,7 +29558,7 @@ function tree_select_select__toConsumableArray(arr) { if (Array.isArray(arr)) { 
     },
     methods: {
         setPosition: function setPosition() {
-            if (!this.$el) return;
+        if (!this.$el || !this.$refs.inputArea) return;
             var p = fn_getOffset(this.$refs.inputArea, this.container);
 
             this.style = {


### PR DESCRIPTION
只在29561行代码 if (!this.$el || !this.$refs.inputArea) return;替换了if (!this.$el) return;
       